### PR TITLE
define map functions and redeclared constants and error codes in seperate contract

### DIFF
--- a/contracts/constants.clar
+++ b/contracts/constants.clar
@@ -1,0 +1,24 @@
+;; Constants and Error Codes
+(define-constant CONTRACT_OWNER tx-sender)
+(define-constant BRIDGE_VERSION "2.0.0")
+
+;; Error codes
+(define-constant ERR_NOT_AUTHORIZED (err u401))
+(define-constant ERR_INVALID_AMOUNT (err u402))
+(define-constant ERR_BRIDGE_PAUSED (err u403))
+(define-constant ERR_CHAIN_NOT_SUPPORTED (err u404))
+(define-constant ERR_INSUFFICIENT_POINTS (err u405))
+(define-constant ERR_INVALID_GUARDIAN (err u406))
+(define-constant ERR_COOLDOWN_ACTIVE (err u407))
+
+;; Status Constants with fixed length of 16 chars
+(define-constant STATUS_PENDING "pending         ")
+(define-constant STATUS_COMPLETED "completed       ")
+(define-constant STATUS_FAILED "failed          ")
+
+;; Export read-only functions
+(define-read-only (get-contract-owner)
+    CONTRACT_OWNER)
+
+(define-read-only (get-bridge-version)
+    BRIDGE_VERSION)

--- a/contracts/data-vars.clar
+++ b/contracts/data-vars.clar
@@ -1,0 +1,24 @@
+;; Data Variables
+(use-trait ft-trait 'SP3FBR2AGK5H9QBDH3EEN6DF8EK8JY7RX8QJ5SVTE.sip-010-trait-ft-standard.sip-010-trait)
+
+(define-data-var contract-paused bool false)
+(define-data-var protocol-fee-bps uint u25) ;; 0.25% base fee
+(define-data-var total-volume uint u0)
+(define-data-var total-bridges uint u0)
+(define-data-var points-per-stx uint u100) ;; 100 points per STX bridged
+
+;; FlowPoints Token
+(define-fungible-token flow-points)
+
+;; Export read-only functions
+(define-read-only (get-contract-status)
+    (var-get contract-paused))
+
+(define-read-only (get-protocol-fee)
+    (var-get protocol-fee-bps))
+
+;; Export public functions
+(define-public (set-contract-status (new-status bool))
+    (begin
+        (asserts! (is-eq tx-sender (contract-call? .constants get-contract-owner)) (err u401))
+        (ok (var-set contract-paused new-status))))

--- a/contracts/profile-manager.clar
+++ b/contracts/profile-manager.clar
@@ -1,0 +1,18 @@
+;; Profile Management Functions
+(define-private (update-user-profile (user principal) (amount uint) (points uint))
+    (let ((current-profile (default-user-profile user)))
+        (map-set user-profiles user
+            (merge current-profile
+                  { total-volume: (+ (get total-volume current-profile) amount),
+                    bridge-count: (+ (get bridge-count current-profile) u1),
+                    flow-points-balance: (+ (get flow-points-balance current-profile) points),
+                    last-bridge: block-height }))))
+
+(define-public (set-guardians (guardian-1 principal) (guardian-2 principal) (guardian-3 principal))
+    (begin
+        (asserts! (not (is-eq guardian-1 guardian-2)) ERR_INVALID_GUARDIAN)
+        (asserts! (not (is-eq guardian-2 guardian-3)) ERR_INVALID_GUARDIAN)
+        (asserts! (not (is-eq guardian-1 guardian-3)) ERR_INVALID_GUARDIAN)
+        (ok (map-set user-profiles tx-sender
+            (merge (default-user-profile tx-sender)
+                  { guardians: (list guardian-1 guardian-2 guardian-3) })))))


### PR DESCRIPTION
## Overview

This Pull request debugs errors by adding necessary error constantsa and new project management functions and variables .

;; Constants and Error Codes
(define-constant CONTRACT_OWNER tx-sender)
(define-constant BRIDGE_VERSION "2.0.0")

;; Error codes
(define-constant ERR_NOT_AUTHORIZED (err u401))
(define-constant ERR_INVALID_AMOUNT (err u402))
(define-constant ERR_BRIDGE_PAUSED (err u403))
(define-constant ERR_CHAIN_NOT_SUPPORTED (err u404))
(define-constant ERR_INSUFFICIENT_POINTS (err u405))
(define-constant ERR_INVALID_GUARDIAN (err u406))
(define-constant ERR_COOLDOWN_ACTIVE (err u407))

;; Status Constants with fixed length of 16 chars
(define-constant STATUS_PENDING "pending         ")
(define-constant STATUS_COMPLETED "completed       ")
(define-constant STATUS_FAILED "failed          ")

;; Export read-only functions
(define-read-only (get-contract-owner)
    CONTRACT_OWNER)

(define-read-only (get-bridge-version)
    BRIDGE_VERSION)





it continues the development stage of stacknet with openness to contributions from other clarity developers

